### PR TITLE
make SWT executable and usable as DataExplorer plugin again

### DIFF
--- a/HoTT-MdlViewer-SWT/pom.xml
+++ b/HoTT-MdlViewer-SWT/pom.xml
@@ -103,7 +103,7 @@
 					<transformers>
 						<transformer
 							implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-							<mainClass>Launcher</mainClass>
+							<mainClass>de.treichels.hott.mdlviewer.swt.Launcher</mainClass>
 						</transformer>
 					</transformers>
 				</configuration>
@@ -133,7 +133,7 @@
 							<errTitle>MdlViewer</errTitle>
 							<icon>icon.ico</icon>
 							<classPath>
-								<mainClass>Launcher</mainClass>
+								<mainClass>de.treichels.hott.mdlviewer.swt.Launcher</mainClass>
 								<addDependencies>false</addDependencies>
 							</classPath>
 							<jre>

--- a/HoTT-MdlViewer-SWT/src/main/java/de/treichels/hott/mdlviewer/swt/Launcher.java
+++ b/HoTT-MdlViewer-SWT/src/main/java/de/treichels/hott/mdlviewer/swt/Launcher.java
@@ -16,7 +16,7 @@ import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
-class Launcher {
+public class Launcher {
     @NonNls
     private static final String LOG_DIR = "log.dir";
     @NonNls

--- a/HoTT-MdlViewer-SWT/src/main/java/de/treichels/hott/mdlviewer/swt/MdlTabItem.java
+++ b/HoTT-MdlViewer-SWT/src/main/java/de/treichels/hott/mdlviewer/swt/MdlTabItem.java
@@ -1,0 +1,51 @@
+/*
+  HoTT Transmitter Config Copyright (C) 2013 Oliver Treichel
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.treichels.hott.mdlviewer.swt;
+
+import org.eclipse.swt.custom.CTabFolder;
+import org.eclipse.swt.custom.CTabItem;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.widgets.Display;
+
+public class MdlTabItem extends CTabItem {
+	public static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().startsWith("windows");
+	public static final boolean IS_LINUX = System.getProperty("os.name").toLowerCase().startsWith("linux");
+	public static final boolean IS_MAC = System.getProperty("os.name").toLowerCase().startsWith("mac");
+	public static final int WIDGET_FONT_SIZE;
+	public static final String WIDGET_FONT_NAME;
+
+	public MdlTabItem(CTabFolder parent, int style) {
+		this(parent, style, 0);
+	}
+
+	public MdlTabItem(CTabFolder parent, int style, int index) {
+		super(parent, style, index);
+		this.setFont(new Font(Display.getDefault(), new FontData(WIDGET_FONT_NAME, WIDGET_FONT_SIZE + 1, 0)));
+		this.setText("MDL Viewer");
+
+		try {
+			if (System.getProperty("program.version") == null) {
+				Launcher.initSystemProperties();
+			}
+		} catch (Exception arg4) {
+				arg4.printStackTrace();
+		}
+
+		this.setControl(new MdlTabItemComposite(parent));
+	}
+
+	static {
+		WIDGET_FONT_SIZE = IS_MAC ? 12 : (IS_LINUX ? 8 : 9) * 96 / Display.getDefault().getDPI().y;
+		WIDGET_FONT_NAME = IS_WINDOWS ? "Microsoft Sans Serif" : "Sans Serif";
+	}
+}

--- a/HoTT-Report-HTML/src/main/java/de/treichels/hott/report/html/HTMLReport.kt
+++ b/HoTT-Report-HTML/src/main/java/de/treichels/hott/report/html/HTMLReport.kt
@@ -40,9 +40,11 @@ object HTMLReport {
 
         // extract font file
         val fontFile = File(System.getProperty("java.io.tmpdir"), "Arial.ttf")
-        ClassLoader.getSystemResourceAsStream("Arial.ttf").use { inputStream ->
-            FileOutputStream(fontFile).use { outputStream -> IOUtils.copy(inputStream, outputStream) }
-        }
+        //can not be loaded within DataExplorer -> inputstream cause NullPointerException
+        if (ClassLoader.getSystemResourceAsStream("Arial.ttf") != null)
+	        	ClassLoader.getSystemResourceAsStream("Arial.ttf").use { inputStream ->
+	            	FileOutputStream(fontFile).use { outputStream -> IOUtils.copy(inputStream, outputStream) }
+	        	}
     }
 
     @Throws(IOException::class, ReportException::class)


### PR DESCRIPTION
four fixes are required to make MDLViewer functional as SWT-version and as plug in in DataExplorer:

- add package qualifier to mainClass to make jar launchable

- change Launcher to public class to make Launcher loadable from DataExplorer to detect MDLViewer.jar 

- add MDLTabItem again to enable loading as tab item in DataExplorer

- check if Arial.ttf inputstream != null and skip copy to workaround NullPointerException while content is used as plug-in of DataExplorer